### PR TITLE
Fix script and command editing paths

### DIFF
--- a/app.py
+++ b/app.py
@@ -461,7 +461,7 @@ class DashboardApp(tk.Tk):
 
     def edit_script(self, idx):
         script = self.scripts[idx]
-        folder = os.path.join(os.path.dirname(__file__), "scripts_folder")
+        folder = USER_SCRIPTS_FOLDER
         file_path = os.path.join(folder, script["filename"])
 
         # Load current file content
@@ -560,7 +560,7 @@ class DashboardApp(tk.Tk):
 
     def edit_cmd(self, idx):
         cmd = self.cmds[idx]
-        folder = os.path.join(os.path.dirname(__file__), "cmds_folder")
+        folder = USER_CMDS_FOLDER
         file_path = os.path.join(folder, cmd["filename"])
 
         # Load current file content
@@ -630,12 +630,10 @@ class DashboardApp(tk.Tk):
                         data = json.load(f)
                         if key == "scripts":
                             self.scripts = data
-                            scripts_folder = os.path.join(os.path.dirname(__file__), "scripts_folder")
-                            self.render_scripts(self.scripts_frame, scripts_folder)
+                            self.render_scripts(self.scripts_frame, USER_SCRIPTS_FOLDER)
                         elif key == "cmds":
                             self.cmds = data
-                            cmds_folder = os.path.join(os.path.dirname(__file__), "cmds_folder")
-                            self.render_cmds(self.cmds_frame, cmds_folder)
+                            self.render_cmds(self.cmds_frame, USER_CMDS_FOLDER)
                 except Exception as e:
                     messagebox.showerror("Error", f"Could not load {key} data: {e}")
 


### PR DESCRIPTION
## Summary
- ensure script and command editors operate on user data directories
- load persisted script and command metadata from user folders

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a66eefb7608323b1db9daf7b8399b2